### PR TITLE
Bugfix: Missing support icon in e-mail

### DIFF
--- a/emails/transactional/password-reset.html
+++ b/emails/transactional/password-reset.html
@@ -232,9 +232,9 @@
                 style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;"
               />
             </a>
-            <a href="https://www.linkedin.com/company/getbud/">
+            <a href="https://getbud.atlassian.net/servicedesk/customer/portals">
               <img
-                src="https://getbud.atlassian.net/servicedesk/customer/portals"
+                src="https://s3-sa-east-1.amazonaws.com/html-bag.s3.getbud.co/icons/support-outline.png"
                 alt="Ícone do helpdesk"
                 style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;"
               />


### PR DESCRIPTION
## ☕ Purpose

This PR fixes the missing support icon in our password reset e-mail